### PR TITLE
Handle complex spectral function

### DIFF
--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -8,8 +8,14 @@ Changes since the last version
 
 The newest version, including changes since the last release, can be obtained using ``git checkout master``.
 
-Right now, there are no changes beyond the last release.
-Maybe there are some feature branches waiting to be explored.
+.. Right now, there are no changes beyond the last release.
+   Maybe there are some feature branches waiting to be explored.
+
+Changes with respect to the last release:
+
+- :py:class:`.IOmegaKernel` for continuing :math:`G(i\omega)`
+  (an object corresponding to :py:class:`.TauMaxEnt` is still missing)
+- :py:class:`.ComplexChi2` and :py:class:`.ComplexPlusMinusEntropy` for continuing complex :math:`A(\omega)`
 
 
 Version 0.9, 2018-08-24

--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -16,6 +16,9 @@ Changes with respect to the last release:
 - :py:class:`.IOmegaKernel` for continuing :math:`G(i\omega)`
   (an object corresponding to :py:class:`.TauMaxEnt` is still missing)
 - :py:class:`.ComplexChi2` and :py:class:`.ComplexPlusMinusEntropy` for continuing complex :math:`A(\omega)`
+  (Note: with the tau kernel, for single matrix elements and the elementwise formalism, it is usually not
+  necessary to continue complex spectral functions in one go. Therefore, this is only interesting for
+  using the :py:class:`.IOmegaKernel` or for the full matrix formalism which will be provided.)
 
 
 Version 0.9, 2018-08-24

--- a/python/cost_functions/maxent_cost_function.py
+++ b/python/cost_functions/maxent_cost_function.py
@@ -102,16 +102,19 @@ class MaxEntCostFunction(CostFunction):
             vector in singular space giving the solution
         """
 
-        dQ_dH = self.dH(v)
+        dQ_dH = self.dH(v).reshape(-1)
 
         if self.d_dv:
             dH_dv = self.H_of_v.d(v)
+            dH_dv = dH_dv.reshape((-1, dH_dv.shape[-1]))
             retval = np.dot(dH_dv.transpose(), dQ_dH)
         else:
             if self.dA_projection == 1:
+                # TODO
                 retval = np.dot(self.chi2.K.V.conjugate().transpose(), dQ_dH)
             elif self.dA_projection == 2:
                 dH_dv = self.H_of_v.d(v)
+                dH_dv = dH_dv.reshape((-1, dH_dv.shape[-1]))
                 retval = np.dot(dH_dv.transpose(), dQ_dH)
             else:
                 retval = dQ_dH
@@ -139,15 +142,20 @@ class MaxEntCostFunction(CostFunction):
 
         ddQ_dHdH = self.ddH(v)
         dH_dv = self.H_of_v.d(v)
+        n_index_H = np.prod(dH_dv.shape[:-1])
+        ddQ_dHdH = ddQ_dHdH.reshape((n_index_H, n_index_H))
+        dH_dv = dH_dv.reshape((n_index_H, -1))
 
         if self.d_dv:
-            dQ_dH = self.dH(v)
-            ddH_dvdv = self.H_of_v.dd(v)
+            dQ_dH = self.dH(v).reshape(-1)
+            ddH_dvdv = self.H_of_v.dd(v).reshape(
+                (-1, dH_dv.shape[-1], dH_dv.shape[-1]))
             # we make use of the fact that the Jacobian is symmetric
             retval = (np.dot(np.dot(ddQ_dHdH, dH_dv).transpose(), dH_dv) +
                       np.einsum('k,kij->ij', dQ_dH, ddH_dvdv))
         else:
             if self.dA_projection == 1:
+                # TODO
                 retval = np.dot(self.chi2.K.V.conjugate().transpose(),
                                 np.dot(ddQ_dHdH, dH_dv))
             elif self.dA_projection == 2:

--- a/python/functions.py
+++ b/python/functions.py
@@ -947,7 +947,7 @@ class IdentityA_of_H(GenericA_of_H):
     @cached
     def f(self, H):
         if(H.ndim == 2):
-            return H / self._omega.delta[:, np.newaxis]
+            return view_complex(H / self._omega.delta[:, np.newaxis])
         else:
             return H / self._omega.delta
 
@@ -961,7 +961,7 @@ class IdentityA_of_H(GenericA_of_H):
 
     @cached
     def inv(self, A):
-        return A * self._omega.delta
+        return view_real(A * self._omega.delta)
 
 
 class PreblurA_of_H(GenericA_of_H):

--- a/python/functions.py
+++ b/python/functions.py
@@ -324,6 +324,14 @@ class Chi2(DoublyDerivableFunction):
 
     data_variable = property(get_data_variable, set_data_variable)
 
+    @property
+    def input_size(self):
+        return (self.K.K.shape[1],)
+
+    @property
+    def axes_preference(self):
+        return (0,)
+
 
 class NormalChi2(Chi2):
     r""" A function giving the usual least squares
@@ -420,6 +428,14 @@ class ComplexChi2(Chi2):
             self.d2[:, 1, :, 1] = -np.imag(E)
             self.d2[:, 1, :, 1] = np.real(E)
 
+    @property
+    def input_size(self):
+        return (self.K.K.shape[1], 2)
+
+    @property
+    def axes_preference(self):
+        return (0, 1)
+
 
 # =====================================================================
 #  Entropy
@@ -462,6 +478,14 @@ class Entropy(DoublyDerivableFunction):
             self.parameter_change()
 
     omega = property(get_omega, set_omega)
+
+    @property
+    def input_size(self):
+        return (len(self.D.D),)
+
+    @property
+    def axes_preference(self):
+        return (0,)
 
 
 class NormalEntropy(Entropy):
@@ -585,6 +609,14 @@ class ComplexPlusMinusEntropy(PlusMinusEntropy):
         dd[:, 1, :, 1] = dd_im
         return dd
 
+    @property
+    def input_size(self):
+        return (len(self.D.D), 2)
+
+    @property
+    def axes_preference(self):
+        return (0, 1)
+
 
 class AbsoluteEntropy(Entropy):
     """ The entropy with ``|A|``
@@ -675,6 +707,14 @@ class GenericH_of_v(DoublyDerivableFunction, InvertibleFunction):
             self.parameter_change()
 
     omega = property(get_omega, set_omega)
+
+    @property
+    def input_size(self):
+        return (len(self.K.S),)
+
+    @property
+    def axes_preference(self):
+        return (0,)
 
 
 class NormalH_of_v(GenericH_of_v):
@@ -824,6 +864,14 @@ class ComplexPlusMinusH_of_v(PlusMinusH_of_v):
             super(ComplexPlusMinusH_of_v, self).inv(
                 view_complex(A)), reshape=False)
 
+    @property
+    def input_size(self):
+        return (2 * len(self.K.S),)
+
+    @property
+    def axes_preference(self):
+        return (0,)
+
 
 class NoExpH_of_v(GenericH_of_v):
     """ Parametrization H(v) without the exponential """
@@ -898,7 +946,10 @@ class IdentityA_of_H(GenericA_of_H):
 
     @cached
     def f(self, H):
-        return H / self._omega.delta
+        if(H.ndim == 2):
+            return H / self._omega.delta[:, np.newaxis]
+        else:
+            return H / self._omega.delta
 
     @cached
     def d(self, H):

--- a/python/maxent_loop.py
+++ b/python/maxent_loop.py
@@ -197,7 +197,7 @@ class MaxEntLoop(object):
         right_side_slice = [np.newaxis] * H.ndim
         for i in self.chi2.axes_preference[:right_side.ndim]:
             right_side_slice[i] = slice(None, None)
-        H[:] = right_side[right_side_slice]
+        H[:] = right_side[tuple(right_side_slice)]
         v = self.H_of_v(H).inv()
 
         # set up result

--- a/python/maxent_loop.py
+++ b/python/maxent_loop.py
@@ -25,7 +25,7 @@ from .logtaker import Logtaker
 from .maxent_result import MaxEntResult
 from .analyzers import *
 from .probabilities import NormalLogProbability
-from .functions import PlusMinusEntropy, PlusMinusH_of_v
+from .functions import PlusMinusEntropy, PlusMinusH_of_v, view_real
 from datetime import datetime
 import numpy as np
 
@@ -185,11 +185,19 @@ class MaxEntLoop(object):
 
         # calculate minimal chi2
         A_min = np.linalg.lstsq(self.K.K, self.G, rcond=-1)[0]
+        if(np.any(np.iscomplex(A_min))):
+            A_min = view_real(A_min)
         chi2_min = self.chi2(A_min).f()
         self.logtaker.logged_message("Minimal chi2: {}", chi2_min)
 
         # the initial value of v
-        H = (self.D.D if self.A_init is None else self.A_init) * self.omega.delta
+        H = np.empty(self.chi2.input_size)
+        right_side = (
+            self.D.D if self.A_init is None else self.A_init) * self.omega.delta
+        right_side_slice = [np.newaxis] * H.ndim
+        for i in self.chi2.axes_preference[:right_side.ndim]:
+            right_side_slice[i] = slice(None, None)
+        H[:] = right_side[right_side_slice]
         v = self.H_of_v(H).inv()
 
         # set up result

--- a/python/maxent_result.py
+++ b/python/maxent_result.py
@@ -85,7 +85,10 @@ def recursive_dtype(seq):
         if isinstance(item, list):
             return recursive_dtype(item)
         else:
-            return item.dtype
+            try:
+                return item.dtype
+            except AttributeError:
+                return type(item)
 
 
 def _get_empty(matrix_structure, fill_with=list, element_wise=True):
@@ -713,7 +716,7 @@ class MaxEntResult(MaxEntResultData):
                           element_wise=self._element_wise,
                           fill_with=fill_with)
 
-    def _forevery(self, func, what=None, dtype=float,
+    def _forevery(self, func, what=None, dtype=None,
                   hermiticity_conjugate=False):
         """ apply a function to every result matrix element """
         if what is None:
@@ -873,7 +876,7 @@ class MaxEntResult(MaxEntResultData):
         In the case of an extra transformation (see :py:meth:`.TauMaxEnt.set_cov`)
         this is the transformed G.
         """
-        return self._forevery(lambda r: r.chi2.G, dtype=None)[..., 0, :]
+        return self._forevery(lambda r: r.chi2.G)[..., 0, :]
 
     @saved
     def G_orig(self):
@@ -886,7 +889,7 @@ class MaxEntResult(MaxEntResultData):
         In the case of an extra transformation (see :py:meth:`.TauMaxEnt.set_cov`)
         this is the original G.
         """
-        return self._forevery(lambda r: r.G_orig, dtype=None)[..., 0, :]
+        return self._forevery(lambda r: r.G_orig)[..., 0, :]
 
     @saved
     def data_variable(self):

--- a/python/maxent_result.py
+++ b/python/maxent_result.py
@@ -79,6 +79,15 @@ def recursive_map(seq, func):
             yield func(item)
 
 
+def recursive_dtype(seq):
+    """ Get the dtype of the first item of seq. """
+    for item in seq:
+        if isinstance(item, list):
+            return recursive_dtype(item)
+        else:
+            return item.dtype
+
+
 def _get_empty(matrix_structure, fill_with=list, element_wise=True):
     """ Return an empty object that has ``len(matrix_structure)`` dimensions
 
@@ -712,6 +721,8 @@ class MaxEntResult(MaxEntResultData):
         if not isinstance(what, Sequence):
             return func(what)
         li = list(recursive_map(what, func))
+        if dtype is None:
+            dtype = recursive_dtype(li)
         arr = np.empty(_find_shape(li), dtype=dtype)
         _fill_array(arr, li)
 
@@ -862,7 +873,7 @@ class MaxEntResult(MaxEntResultData):
         In the case of an extra transformation (see :py:meth:`.TauMaxEnt.set_cov`)
         this is the transformed G.
         """
-        return self._forevery(lambda r: r.chi2.G)[..., 0, :]
+        return self._forevery(lambda r: r.chi2.G, dtype=None)[..., 0, :]
 
     @saved
     def G_orig(self):
@@ -875,7 +886,7 @@ class MaxEntResult(MaxEntResultData):
         In the case of an extra transformation (see :py:meth:`.TauMaxEnt.set_cov`)
         this is the original G.
         """
-        return self._forevery(lambda r: r.G_orig)[..., 0, :]
+        return self._forevery(lambda r: r.G_orig, dtype=None)[..., 0, :]
 
     @saved
     def data_variable(self):

--- a/python/maxent_util.py
+++ b/python/maxent_util.py
@@ -25,6 +25,7 @@ MaxEnt.
 from __future__ import absolute_import, print_function
 
 import numpy as np
+from itertools import product
 from .triqs_support import *
 if if_triqs_1():
     from pytriqs.gf.local import *
@@ -181,18 +182,18 @@ def numder(fun, x, delta=1.e-6):
     """
     x2 = np.empty(x.shape)
     dfun = None
-    for i in range(len(x)):
+    for i in product(*map(range, x.shape)):
         x2[:] = x
         x2[i] += delta
         funplus = fun(x2)
         x2[i] -= 2 * delta
         funminus = fun(x2)
         if dfun is None:
-            try:
-                dfun = np.empty(funplus.shape + (len(x2),))
-            except TypeError:
-                dfun = np.empty((1, len(x2)))
-        dfun[..., i] = (funplus - funminus) / (2.0 * delta)
+            if len(funplus.shape) == 0:
+                dfun = np.empty((1,) + x2.shape, dtype=funplus.dtype)
+            else:
+                dfun = np.empty(funplus.shape + x2.shape, dtype=funplus.dtype)
+        dfun[(Ellipsis,) + i] = (funplus - funminus) / (2.0 * delta)
     return dfun
 
 

--- a/python/plot_utils.py
+++ b/python/plot_utils.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import, print_function
 import matplotlib.pyplot as plt
 from functools import wraps
+import numpy as np
 
 
 def plot_function(func):
@@ -91,6 +92,12 @@ def _plotter(x, y, label=None, x_label=None, y_label=None,
     elif log_y:
         plot_command = plt.semilogy
 
-    plot_command(x, y, label=label)
+    if np.any(np.iscomplex(y)):
+        plot_command(x, y.real,
+                     label='Re ' + label if label is not None else None)
+        plot_command(x, y.imag,
+                     label='Im ' + label if label is not None else None)
+    else:
+        plot_command(x, y, label=label)
     plt.xlabel(x_label)
     plt.ylabel(y_label)

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -14,7 +14,7 @@ set(general_tests omega_meshes minimizer_cubefun minimizer_circlefun
     maxent_cost_function_d functions_different_grid tau_kernel alpha_meshes
     default_models logtaker matrix_maxent_result maxent_loop tau_maxent
     bryan_cost_function huge_alpha cov elementwise_maxent elementwise_set_G
-    pickle_maxent_result)
+    pickle_maxent_result complex_A)
 
 set(triqs_tests maxent_result analyzers set_G_tau set_G_tau_complex_matrix
     tau_maxent_off srvo3_mesh_and_ALPS complex_elementwise_maxent G_w_from_A_w

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -56,10 +56,10 @@ assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 1]))) < 1.e-14
 assert (np.max(np.abs(c2_complex.dd()[:, 1, :, 0]))) < 1.e-14
 
 D = 0.3 - 0.1j + 0 * A
-chi2_rp.check_derivatives(D.real, chi2_rp.f(D.real))
-chi2_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
+assert chi2_rp.check_derivatives(D.real, chi2_rp.f(D.real))
+assert chi2_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
 D_view = D.view(float).reshape(A.shape + (2,))
-chi2_complex.check_derivatives(D_view, chi2_complex.f(D_view))
+assert chi2_complex.check_derivatives(D_view, chi2_complex.f(D_view))
 
 iomega = np.linspace(-(2 * 48 + 1) * np.pi / beta,
                      (2 * 48 + 1) * np.pi / beta, len(tau) - 2)
@@ -72,6 +72,26 @@ err_iw = 1.e-4 * np.ones(len(G_iw_K))
 chi2_iw_rp = NormalChi2(K=K_iw, G=np.dot(K_iw.K, A.real), err=err_iw)
 chi2_iw_ip = NormalChi2(K=K_iw, G=np.dot(K_iw.K, A.imag), err=err_iw)
 chi2_iw_complex = ComplexChi2(K=K_iw, G=G_iw_K, err=err_iw)
-chi2_iw_rp.check_derivatives(D.real, chi2_rp.f(D.real))
-chi2_iw_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
-chi2_iw_complex.check_derivatives(D_view, chi2_complex.f(D_view))
+assert chi2_iw_rp.check_derivatives(D.real, chi2_rp.f(D.real))
+assert chi2_iw_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
+assert chi2_iw_complex.check_derivatives(D_view, chi2_complex.f(D_view))
+
+Def = FlatDefaultModel(omega=omega)
+entropy_normal = PlusMinusEntropy(D=Def)
+entropy_complex = ComplexPlusMinusEntropy(D=Def)
+S_rp = entropy_normal(A.real)
+S_ip = entropy_normal(A.imag)
+S_complex = entropy_complex(A.view(float).reshape(A.shape + (2,)))
+assert (np.abs(S_rp.f() + S_ip.f() - S_complex.f())) < 1.e-13
+assert (np.max(np.abs(S_complex.d()[:, 0] - S_rp.d()))) < 1.e-10
+assert (np.max(np.abs(S_complex.d()[:, 1] - S_ip.d()))) < 1.e-10
+assert (S_complex.d().shape == c2_complex.d().shape)
+assert (S_complex.dd().shape == c2_complex.dd().shape)
+assert (np.max(np.abs(S_complex.dd()[:, 0, :, 0] - S_rp.dd()))) < 1.e-14
+assert (np.max(np.abs(S_complex.dd()[:, 1, :, 1] - S_ip.dd()))) < 1.e-14
+assert (np.max(np.abs(S_complex.dd()[:, 0, :, 1]))) < 1.e-14
+assert (np.max(np.abs(S_complex.dd()[:, 1, :, 0]))) < 1.e-14
+
+assert S_rp.check_derivatives(D.real, S_rp.f(D.real))
+assert S_ip.check_derivatives(D.imag, S_ip.f(D.imag))
+assert S_complex.check_derivatives(D_view, S_complex.f(D_view))

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -111,3 +111,13 @@ assert H_iw.check_derivatives(v_iw)
 # I'm not too happy with the precision but inverting non-bijective functions
 # is always tricky...
 assert H_iw.check_inv(D_view, prec=1.e-2)
+
+Q = MaxEntCostFunction(chi2=chi2_complex, S=entropy_complex, H_of_v=H_of_v)
+Q.set_alpha(1.0)
+assert Q.dH(v).shape == (100, 2)
+assert H_of_v.d(v).shape == (100, 2, 200)
+assert Q.d(v).shape == (200,)
+
+assert Q.ddH(v).shape == (100, 2, 100, 2)
+assert H_of_v.dd(v).shape == (100, 2, 200, 200)
+assert Q.dd(v).shape == (200, 200)

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -60,9 +60,12 @@ chi2_complex = ComplexChi2(K=K, G=G, err=err)
 c2_rp = chi2_rp(A.real)
 c2_ip = chi2_ip(A.imag)
 c2_complex = chi2_complex(A.view(float).reshape(A.shape + (2,)))
-assert (np.abs(c2_rp.f() + c2_ip.f() - c2_complex.f())) < 1.e-10
-assert (np.max(np.abs(c2_complex.d()[:, 0] - c2_rp.d()))) < 1.e-5
-assert (np.max(np.abs(c2_complex.d()[:, 1] - c2_ip.d()))) < 1.e-5
+assert (np.abs(c2_rp.f() + c2_ip.f() - c2_complex.f())) / \
+    c2_complex.f() / len(omega) < 1.e-13
+assert ( np.max( np.abs( c2_complex.d()[:, 0] - c2_rp.d()))) \
+    / c2_complex.f() / len(omega) < 1.e-9
+assert ( np.max( np.abs( c2_complex.d()[:, 1] - c2_ip.d()))) \
+    / c2_complex.f() / len(omega) < 1.e-9
 assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 0] - c2_rp.dd()))) < 1.e-14
 assert (np.max(np.abs(c2_complex.dd()[:, 1, :, 1] - c2_ip.dd()))) < 1.e-14
 assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 1]))) < 1.e-14

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -121,3 +121,20 @@ assert Q.d(v).shape == (200,)
 assert Q.ddH(v).shape == (100, 2, 100, 2)
 assert H_of_v.dd(v).shape == (100, 2, 200, 200)
 assert Q.dd(v).shape == (200, 200)
+
+logtaker = Logtaker()
+
+minimizer = LevenbergMinimizer(maxiter=10000)
+
+alpha_values = LogAlphaMesh(alpha_max=6000, alpha_min=8, n_points=5)
+
+ml = MaxEntLoop(cost_function=Q, minimizer=minimizer,
+                alpha_mesh=alpha_values, logtaker=logtaker)
+result = ml.run()
+
+if not if_no_triqs():
+    from pytriqs.archive import HDFArchive
+    with HDFArchive('maxent_loop.h5', 'w') as ar:
+        ar['result_complex'] = result.data
+else:
+    result.data

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -60,9 +60,9 @@ chi2_complex = ComplexChi2(K=K, G=G, err=err)
 c2_rp = chi2_rp(A.real)
 c2_ip = chi2_ip(A.imag)
 c2_complex = chi2_complex(A.view(float).reshape(A.shape + (2,)))
-assert (np.abs(c2_rp.f() + c2_ip.f() - c2_complex.f())) < 1.e-13
-assert (np.max(np.abs(c2_complex.d()[:, 0] - c2_rp.d()))) < 1.e-10
-assert (np.max(np.abs(c2_complex.d()[:, 1] - c2_ip.d()))) < 1.e-10
+assert (np.abs(c2_rp.f() + c2_ip.f() - c2_complex.f())) < 1.e-10
+assert (np.max(np.abs(c2_complex.d()[:, 0] - c2_rp.d()))) < 1.e-5
+assert (np.max(np.abs(c2_complex.d()[:, 1] - c2_ip.d()))) < 1.e-5
 assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 0] - c2_rp.dd()))) < 1.e-14
 assert (np.max(np.abs(c2_complex.dd()[:, 1, :, 1] - c2_ip.dd()))) < 1.e-14
 assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 1]))) < 1.e-14
@@ -123,7 +123,7 @@ assert H_iw.f().shape == (100, 2)
 assert H_iw.check_derivatives(v_iw)
 # I'm not too happy with the precision but inverting non-bijective functions
 # is always tricky...
-assert H_iw.check_inv(D_view, prec=1.e-2)
+assert H_iw.check_inv(D_view, prec=1.e-1)
 
 #######################################################################
 # MaxEnt with complex G(tau)

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -95,3 +95,19 @@ assert (np.max(np.abs(S_complex.dd()[:, 1, :, 0]))) < 1.e-14
 assert S_rp.check_derivatives(D.real, S_rp.f(D.real))
 assert S_ip.check_derivatives(D.imag, S_ip.f(D.imag))
 assert S_complex.check_derivatives(D_view, S_complex.f(D_view))
+
+v = np.ones(2 * len(K.S))
+H_of_v = ComplexPlusMinusH_of_v(D=Def, K=K)
+H = H_of_v(v)
+assert H.f().shape == (100, 2)
+assert H.check_derivatives(v)
+assert H.check_inv(D_view)
+
+v_iw = np.ones(2 * len(K_iw.S))
+H_of_v_iw = ComplexPlusMinusH_of_v(D=Def, K=K_iw)
+H_iw = H_of_v_iw(v_iw)
+assert H_iw.f().shape == (100, 2)
+assert H_iw.check_derivatives(v_iw)
+# I'm not too happy with the precision but inverting non-bijective functions
+# is always tricky...
+assert H_iw.check_inv(D_view, prec=1.e-2)

--- a/test/python/complex_A.py
+++ b/test/python/complex_A.py
@@ -1,0 +1,77 @@
+# TRIQS application maxent
+# Copyright (C) 2018 Gernot J. Kraberger
+# Copyright (C) 2018 Simons Foundation
+# Authors: Gernot J. Kraberger and Manuel Zingl
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from __future__ import absolute_import, print_function
+import numpy as np
+from triqs_maxent import *
+from triqs_maxent.triqs_support import *
+
+# to make it reproducible
+np.random.seed(658436166)
+
+beta = 40
+tau = np.linspace(0, beta, 100)
+omega = HyperbolicOmegaMesh(omega_min=-10, omega_max=10, n_points=100)
+K = TauKernel(tau=tau, omega=omega, beta=beta)
+# here we construct the G(tau)
+A = np.exp(-(omega - 1)**2) - np.exp(-(omega + 1)**2) + \
+    (-1.0j) * (np.exp(-(omega - 1)**2) - np.exp(-(omega + 1)**2))
+assert np.abs(np.trapz(A, omega)) < 1.e-14, "A not normalized to 0"
+
+G = np.dot(K.K, A)
+G += 1.e-4 * np.random.randn(len(G))
+G += 1.e-4j * np.random.randn(len(G))
+err = 1.e-4 * np.ones(len(G))
+
+chi2_rp = NormalChi2(K=K, G=G.real, err=err)
+chi2_ip = NormalChi2(K=K, G=G.imag, err=err)
+chi2_complex = ComplexChi2(K=K, G=G, err=err)
+# this should be around the number of data points, here 200, because we
+# have real and imag part for 100 values
+c2_rp = chi2_rp(A.real)
+c2_ip = chi2_ip(A.imag)
+c2_complex = chi2_complex(A.view(float).reshape(A.shape + (2,)))
+assert (np.abs(c2_rp.f() + c2_ip.f() - c2_complex.f())) < 1.e-13
+assert (np.max(np.abs(c2_complex.d()[:, 0] - c2_rp.d()))) < 1.e-10
+assert (np.max(np.abs(c2_complex.d()[:, 1] - c2_ip.d()))) < 1.e-10
+assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 0] - c2_rp.dd()))) < 1.e-14
+assert (np.max(np.abs(c2_complex.dd()[:, 1, :, 1] - c2_ip.dd()))) < 1.e-14
+assert (np.max(np.abs(c2_complex.dd()[:, 0, :, 1]))) < 1.e-14
+assert (np.max(np.abs(c2_complex.dd()[:, 1, :, 0]))) < 1.e-14
+
+D = 0.3 - 0.1j + 0 * A
+chi2_rp.check_derivatives(D.real, chi2_rp.f(D.real))
+chi2_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
+D_view = D.view(float).reshape(A.shape + (2,))
+chi2_complex.check_derivatives(D_view, chi2_complex.f(D_view))
+
+iomega = np.linspace(-(2 * 48 + 1) * np.pi / beta,
+                     (2 * 48 + 1) * np.pi / beta, len(tau) - 2)
+K_iw = IOmegaKernel(iomega, omega, beta=beta)
+G_iw_K = np.dot(K_iw.K, A)
+G_iw_K += 1.e-4 * np.random.randn(len(G_iw_K))
+G_iw_K += 1.e-4j * np.random.randn(len(G_iw_K))
+err_iw = 1.e-4 * np.ones(len(G_iw_K))
+
+chi2_iw_rp = NormalChi2(K=K_iw, G=np.dot(K_iw.K, A.real), err=err_iw)
+chi2_iw_ip = NormalChi2(K=K_iw, G=np.dot(K_iw.K, A.imag), err=err_iw)
+chi2_iw_complex = ComplexChi2(K=K_iw, G=G_iw_K, err=err_iw)
+chi2_iw_rp.check_derivatives(D.real, chi2_rp.f(D.real))
+chi2_iw_ip.check_derivatives(D.imag, chi2_ip.f(D.imag))
+chi2_iw_complex.check_derivatives(D_view, chi2_complex.f(D_view))

--- a/test/python/maxent_loop.py
+++ b/test/python/maxent_loop.py
@@ -77,7 +77,7 @@ result = ml.run()
 
 if not if_no_triqs():
     from pytriqs.archive import HDFArchive
-    with HDFArchive('maxent_loop.h5', 'w') as ar:
+    with HDFArchive('maxent_loop.h5', 'a') as ar:
         ar['result'] = result.data
 else:
     result.data


### PR DESCRIPTION
As a first step to the inclusion of the full matrix scheme in this code, I added the treatment of complex spectral functions. Note that when using the G(tau) kernel, this is utterly useless because one can also treat real and imag part independently. Therefore, I implemented the G(iw) kernel (but not the corresponding object to the TauMaxEnt class), where the two effects are mixed. (Of course, an indirect approach where one performs an inverse FT of G(iw) and then FT back the real part of G(tau) to get the G(iw) describing the real part of A would be possible, making it even not strictly necessary in that case either - however, in the full matrix scheme we need also complex treatment.)

I performed a test (it is included and called ``complex_A``) that goes well. 

Does anyone want to have a closer look or should I just merge?