### PR TITLE
Create font cache ahead of time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
     - name: Test triqs_maxent
       env:
         DYLD_FALLBACK_LIBRARY_PATH: /usr/local/opt/llvm/lib
+        OPENBLAS_NUM_THREADS: "1"
       run: |
         source $HOME/install/share/triqs/triqsvars.sh
         cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         python3-scipy
         python3-sphinx
         python3-nbsphinx
+        && python3 -c "import matplotlib.pyplot"
 
     - name: Install homebrew dependencies
       if: matrix.os == 'macos-12'


### PR DESCRIPTION
This should fix the segfaults caused by the adverse interaction of stdlibc++'s and libc++'s exception handlers.